### PR TITLE
fix controller error in question editor when taxomonies are used

### DIFF
--- a/classes/class.assCodeQuestionGUI.php
+++ b/classes/class.assCodeQuestionGUI.php
@@ -13,6 +13,7 @@ require_once './Modules/TestQuestionPool/interfaces/interface.ilGuiAnswerScoring
  * @ingroup ModulesTestQuestionPool
  *
  * @ilctrl_iscalledby assCodeQuestionGUI: ilObjQuestionPoolGUI, ilObjTestGUI, ilQuestionEditGUI, ilTestExpressPageObjectGUI
+ * @ilCtrl_Calls assCodeQuestionGUI: ilFormPropertyDispatchGUI
  */
 class assCodeQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "codeqst";
 
 // code version; must be changed for all code changes
-$version = "1.1.3";
+$version = "1.1.4";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin


### PR DESCRIPTION
When a taxonomy exist in a question pool, then the editing form of a question is automatically extended with a tree selector for taxonomy nodes. This requires the declarationof an additional controller call in the gui class of the question.