### PR TITLE
Fix title row highlighting in xls export.

### DIFF
--- a/classes/class.assCodeQuestion.php
+++ b/classes/class.assCodeQuestion.php
@@ -757,8 +757,9 @@ class assCodeQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 		}
 
 		if ($il52){
-			$worksheet->setCell($startrow, 0, $this->plugin->txt($this->getQuestionType()));
-			$worksheet->setCell($startrow, 1, $this->getTitle());	
+			// also see parent::setExportDetailsXLS($worksheet, $startrow, $active_id, $pass);
+			$worksheet->setFormattedExcelTitle($worksheet->getColumnCoord(0) . $startrow, $this->plugin->txt($this->getQuestionType()));
+			$worksheet->setFormattedExcelTitle($worksheet->getColumnCoord(1) . $startrow, $this->getTitle());
 		} else {
 			$worksheet->writeString($startrow, 0, ilExcelUtils::_convert_text($this->plugin->txt($this->getQuestionType())), $format_title);
 			$worksheet->writeString($startrow, 1, ilExcelUtils::_convert_text($this->getTitle()), $format_title);


### PR DESCRIPTION
Momentan wird im XLS-Export in den Teilnehmerbögen die Titelzeile der Code-Questions nicht gehighlighted (so wie bei anderen Fragen), vgl.:

<img width="451" alt="current" src="https://user-images.githubusercontent.com/25431384/51306235-20f89500-1a3d-11e9-98e0-f78c753abc03.png">

Der PR fügt (für ILIAS >= 5.2) ein solches Highlighting hinzu (via `setFormattedExcelTitle`):

![fixed](https://user-images.githubusercontent.com/25431384/51306269-353c9200-1a3d-11e9-826f-76e9a297d7da.png)
