### PR TITLE
Disable string escaping on code in xls export.

### DIFF
--- a/classes/class.assCodeQuestion.php
+++ b/classes/class.assCodeQuestion.php
@@ -768,8 +768,11 @@ class assCodeQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 		// now provide a result string and write it to excel
 		// it is also possible to write multiple rows
 		if ($il52){
+			$stringEscaping = $worksheet->getStringEscaping();
+			$worksheet->setStringEscaping(false);
 			$worksheet->setCell($startrow + $i, 0, $this->plugin->txt("label_value1"));
-			$worksheet->setCell($startrow + $i, 1, $value1);	
+			$worksheet->setCell($startrow + $i, 1, $value1);
+			$worksheet->setStringEscaping($stringEscaping);
 		} else {
 			$worksheet->writeString($startrow + $i, 0, ilExcelUtils::_convert_text($this->plugin->txt("label_value1")), $format_bold);
 			$worksheet->write($startrow + $i, 1, ilExcelUtils::_convert_text($value1));


### PR DESCRIPTION
Bei bestimmten Code-Fragmenten wird im XLS nicht das exportiert, was im Code stand.

Man nehme folgenden fabrizierten String:

```
+<>D\r\n<\u00a7>\r\nL<>*\r\n<q>\r\nI<
```

Im XLS exportiert wird eine truncated version davon:

![without-pr](https://user-images.githubusercontent.com/25431384/51386209-f2a0b580-1b21-11e9-9259-6c0f6ed04543.png)

Mit dem PR wird alles exportiert:

![with-pr](https://user-images.githubusercontent.com/25431384/51386240-06e4b280-1b22-11e9-88d3-7aa6df6fcfaa.png)

Der PR behebt das Problem für ILIAS >= 5.2.
