### PR TITLE
Update ilias54

### DIFF
--- a/classes/class.assCodeQuestionGUI.php
+++ b/classes/class.assCodeQuestionGUI.php
@@ -628,15 +628,18 @@ class assCodeQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
 	/**
 	 * Returns the answer specific feedback for the question
-	 * 
-	 * @param integer $active_id Active ID of the user
-	 * @param integer $pass Active pass
+	 *
+	 * This method should be overwritten by the actual question.
+	 *
+	 * @todo Mark this method abstract!
+	 * @param array $userSolution ($userSolution[<value1>] = <value2>)
 	 * @return string HTML Code with the answer specific feedback
 	 * @access public
 	 */
-	function getSpecificFeedbackOutput($active_id, $pass)
+	function getSpecificFeedbackOutput($userSolution)
 	{
 		// By default no answer specific feedback is defined
+		$output = '';
 		return $this->object->prepareTextareaOutput($output, TRUE);
 	}
 	

--- a/plugin.php
+++ b/plugin.php
@@ -8,8 +8,8 @@ $version = "1.1.8";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin
-$ilias_min_version = "5.1";
-$ilias_max_version = "5.3";
+$ilias_min_version = "5.4";
+$ilias_max_version = "5.4";
 
 // optional, but useful: Add one or more responsible persons and a contact email
 $responsible = "Frank Bauer";

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "codeqst";
 
 // code version; must be changed for all code changes
-$version = "1.1.8";
+$version = "1.2.0";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin


### PR DESCRIPTION
hab gerade das Plugin für ILIAS 5.4 aktualisiert. Bei assQuestionGUI::getSpecificFeedbackOutput() hat sich die Signatur geändert, darum sind die Fragen-Plugins für 5.4 nicht mehr rückwärtskompatibel zu 5.3. Man müsste also für 5.3 einen Release-Branch erzeugen oder für 5.4 einen neuen master-ilias54.

Das ScoreIntergration-Plugin scheint ohne Änderung weiter zu funktionieren.

