### PR TITLE
Solves ILIAS 7.13+ fromXML method definition change

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ Alternativley you may use the built-in setup function to prepare a default Three
 
 
 ## Version History
+### Version 2.0.5
+* No longer Blocked Fix by jcop on behalf of SURLABS, SL.
+* Support for ILIAS 7.13+ (fromXML Block commit)
+* Fixed blocking issue with Get Preview Tabs
 ### Version 2.0.3
 * Support for ILILAS 7
 * Fixed issue with css body pollution

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **Author**:   Frank Bauer <frank.bauer@fau.de>
 
-**Version**:  2.0.3
+**Version**:  2.0.5
 
 **Company**:  Friedrich-Alexander-Universität, Visual Computing
 
-**Supports**: ILIAS 7
+**Supports**: ILIAS 7.13+
 
 ## Installation
 1. Copy the `assCodeQuestion` directory to your ILIAS installation at the following path 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Alternativley you may use the built-in setup function to prepare a default Three
 
 ## Version History
 ### Version 2.0.5
-* No longer Blocked Fix by jcop on behalf of SURLABS, SL.
+* Fix by jcopado on behalf of SURLABS.
 * Support for ILIAS 7.13+ (fromXML Block commit)
 * Fixed blocking issue with Get Preview Tabs
 ### Version 2.0.3

--- a/classes/class.assCodeQuestion.php
+++ b/classes/class.assCodeQuestion.php
@@ -835,11 +835,10 @@ class assCodeQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 	 * @access public
 	 * @see assQuestion::fromXML()
 	 */
-	function fromXML(&$item, &$questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
-	{
+	public function fromXML(&$item, &$questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping, array $solutionhints = []): void	{
 		$this->getPlugin()->includeClass("import/qti12/class.assCodeQuestionImport.php");
 		$import = new assCodeQuestionImport($this);
-		$import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+		$import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping, $solutionhints);
 	}
 
 	/**

--- a/classes/class.assCodeQuestionGUI.php
+++ b/classes/class.assCodeQuestionGUI.php
@@ -482,7 +482,7 @@ class assCodeQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 			}
 	
 			// edit page
-			$this->addTab_QuestionPreview($ilTabs);
+			$ilTabs->addTarget("preview", $this->ctrl->getLinkTargetByClass("ilAssQuestionPreviewGUI", "show"), array("preview"), "ilAssQuestionPageGUI", "", "");
 		}
 
 		$force_active = false;

--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@ $version = "2.0.5";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin
-$ilias_min_version = "7.0";
+$ilias_min_version = "7.13";
 $ilias_max_version = "7.999";
 
 // optional, but useful: Add one or more responsible persons and a contact email

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "codeqst";
 
 // code version; must be changed for all code changes
-$version = "2.0.4";
+$version = "2.0.5";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin


### PR DESCRIPTION
This version works only with ILIAS 7.13+ platforms
After TA 28356 Export/Import Solution Hints in ILIAS 7.13, the fromXML method definition in assQuestion has a new parameter, this breaks all question plugins and this pull request solves it, and also doesn't call the now non existing method "addTab_QuestionPreview" 
